### PR TITLE
Keep template defined var order

### DIFF
--- a/bin/genvv
+++ b/bin/genvv
@@ -24,6 +24,7 @@ function printHelp() {
     General options:
       --help                Print this help info and exit
       --version             Print version of this command and exit
+      --allow-missing       Allow missing ENV vars between providers and .env file
     
     Runtime options:
       --aws                 Specifies we're gonna use AWS providers
@@ -58,12 +59,14 @@ function cleanArgvs() {
     herokuToken: argv['heroku-token'],
     herokuAppName: argv['heroku-app-name'],
     providerPaths: argv['provider-paths'],
+    allowMissing: argv['allow-missing'],
   };
 
   return args;
 }
 
 const runner = require('../dist/runner').default;
+
 runner({ params: cleanArgvs(), version: getVersion() })
   .then(() => process.exit())
   .catch(e => {

--- a/bin/genvv
+++ b/bin/genvv
@@ -24,7 +24,6 @@ function printHelp() {
     General options:
       --help                Print this help info and exit
       --version             Print version of this command and exit
-      --allow-missing       Allow missing ENV vars between providers and .env file
     
     Runtime options:
       --aws                 Specifies we're gonna use AWS providers
@@ -59,14 +58,12 @@ function cleanArgvs() {
     herokuToken: argv['heroku-token'],
     herokuAppName: argv['heroku-app-name'],
     providerPaths: argv['provider-paths'],
-    allowMissing: argv['allow-missing'],
   };
 
   return args;
 }
 
 const runner = require('../dist/runner').default;
-
 runner({ params: cleanArgvs(), version: getVersion() })
   .then(() => process.exit())
   .catch(e => {

--- a/src/get-env-vars.ts
+++ b/src/get-env-vars.ts
@@ -51,13 +51,10 @@ const main = async ({
 
   const templateKeys = template?.map(([key]) => key);
   if (!allowMissing && templateKeys) {
-    // get a list of keys that have values
-    const filledKeys = result
-      .filter(([key, value]) => !!value)
-      .map(([key]) => key);
+    const resultKeys = result.map(([key]) => key);
 
     // get a list of keys missing from the results
-    const missingKeys = difference(templateKeys, filledKeys);
+    const missingKeys = difference(templateKeys, resultKeys);
 
     // throw error if not all of the keys have been filled with values
     if (missingKeys.length) {

--- a/src/get-env-vars.ts
+++ b/src/get-env-vars.ts
@@ -24,7 +24,9 @@ const main = async ({
   const template = fileLocation
     ? await mapFileToKeyValueTuple(fileLocation)
     : undefined;
-  const filledTemplateEnvs = (template || []).filter(([key, value]) => !!value);
+  const filledTemplateEnvs = (template || []).filter(
+    ([, value]) => value !== undefined
+  );
 
   const providedEnvs = await Promise.all(
     providers.map(provider => provider({ keys: templateKeys, options: config }))

--- a/src/get-env-vars.ts
+++ b/src/get-env-vars.ts
@@ -1,9 +1,13 @@
-import mapFileToObject from './map-env-file-to-object';
+import mapFileToKeyValueTuple, {
+  KeyValueTuple,
+} from './map-env-file-to-key-value-tuple';
+
+type Provider = (params: any) => Promise<Record<string, string>>;
 
 interface IGetEnvVarsParams {
-  fileLocation: any;
+  fileLocation?: string;
   config: any;
-  providers: any;
+  providers: Provider[];
 }
 
 const difference = (a: Array<any>, b: Array<any>) => {
@@ -14,45 +18,49 @@ const main = async ({
   fileLocation,
   config,
   providers = [],
-}: IGetEnvVarsParams) => {
-  const template =
-    typeof fileLocation === 'string'
-      ? await mapFileToObject(fileLocation)
-      : Promise.resolve(fileLocation);
-  const templateKeys = Object.keys(template);
+}: IGetEnvVarsParams): Promise<KeyValueTuple[]> => {
+  const template = fileLocation
+    ? await mapFileToKeyValueTuple(fileLocation)
+    : undefined;
+  const filledTemplateEnvs = (template || []).filter(([key, value]) => !!value);
 
-  const data = await Promise.all(
-    providers.map((provider: any) =>
-      provider({ keys: templateKeys, options: config })
-    )
+  const providedEnvs = await Promise.all(
+    providers.map(provider => provider({ keys: templateKeys, options: config }))
   );
 
-  if (data.find(entry => typeof entry !== 'object')) {
+  if (providedEnvs.find(env => typeof env !== 'object')) {
     throw new Error('providers must return an object');
   }
 
-  // clean template from undefined values
-  Object.keys(template).forEach(
-    key => template[key] === undefined && delete template[key]
-  );
+  const mergedProvidedEnvs = Object.assign({}, ...providedEnvs) as Record<
+    string,
+    string
+  >;
 
-  // create an array of all data, including template values
-  let parts = [{}].concat(data.reverse()).concat(template);
+  // merge template tuples with fetched envs but keep the template values when defined
+  const result = [
+    ...filledTemplateEnvs,
+    ...Object.entries(mergedProvidedEnvs).filter(
+      ([key]) => !filledTemplateEnvs?.find(([_key, value]) => _key === key)
+    ),
+  ];
 
-  // merge values with latter elements taking precedence
-  const result = Object.assign({}, ...parts);
+  const templateKeys = template?.map(([key]) => key);
+  if (templateKeys) {
+    // get a list of keys that have values
+    const filledKeys = result
+      .filter(([key, value]) => !!value)
+      .map(([key]) => key);
 
-  // get a list of keys that have values
-  const filledKeys = Object.keys(result as Record<string, any>).filter(
-    (key: string) => result[key as any] !== undefined
-  );
+    // get a list of keys missing from the results
+    const missingKeys = difference(templateKeys, filledKeys);
 
-  // get a list of keys missing from the results
-  const missingKeys = difference(templateKeys, filledKeys);
-
-  // throw error if not all of the keys have been filled with values
-  if (missingKeys.length) {
-    throw new Error(`Result is missing required values: ${missingKeys.join()}`);
+    // throw error if not all of the keys have been filled with values
+    if (missingKeys.length) {
+      throw new Error(
+        `Result is missing required values: ${missingKeys.join()}`
+      );
+    }
   }
 
   return result;

--- a/src/get-env-vars.ts
+++ b/src/get-env-vars.ts
@@ -8,6 +8,7 @@ interface IGetEnvVarsParams {
   fileLocation?: string;
   config: any;
   providers: Provider[];
+  allowMissing?: boolean;
 }
 
 const difference = (a: Array<any>, b: Array<any>) => {
@@ -18,6 +19,7 @@ const main = async ({
   fileLocation,
   config,
   providers = [],
+  allowMissing = false,
 }: IGetEnvVarsParams): Promise<KeyValueTuple[]> => {
   const template = fileLocation
     ? await mapFileToKeyValueTuple(fileLocation)
@@ -46,7 +48,7 @@ const main = async ({
   ];
 
   const templateKeys = template?.map(([key]) => key);
-  if (templateKeys) {
+  if (!allowMissing && templateKeys) {
     // get a list of keys that have values
     const filledKeys = result
       .filter(([key, value]) => !!value)

--- a/src/get-env-vars.ts
+++ b/src/get-env-vars.ts
@@ -8,7 +8,6 @@ interface IGetEnvVarsParams {
   fileLocation?: string;
   config: any;
   providers: Provider[];
-  allowMissing?: boolean;
 }
 
 const difference = (a: Array<any>, b: Array<any>) => {
@@ -19,7 +18,6 @@ const main = async ({
   fileLocation,
   config,
   providers = [],
-  allowMissing = false,
 }: IGetEnvVarsParams): Promise<KeyValueTuple[]> => {
   const template = fileLocation
     ? await mapFileToKeyValueTuple(fileLocation)
@@ -50,7 +48,7 @@ const main = async ({
   ];
 
   const templateKeys = template?.map(([key]) => key);
-  if (!allowMissing && templateKeys) {
+  if (templateKeys) {
     const resultKeys = result.map(([key]) => key);
 
     // get a list of keys missing from the results

--- a/src/map-env-file-to-key-value-tuple.ts
+++ b/src/map-env-file-to-key-value-tuple.ts
@@ -1,0 +1,24 @@
+import { readFile, existsSync } from 'fs';
+import { promisify } from 'util';
+import { isNotCommentLine, parseLineAsKeyValue } from './utils';
+
+export type KeyValueTuple = [string, string | number];
+
+const readFileAsync = promisify(readFile);
+
+const main = async (fileLocation: any) => {
+  if (!existsSync(fileLocation)) {
+    throw new Error(`Source env file not found: ${fileLocation}`);
+  }
+
+  const data = await readFileAsync(fileLocation);
+
+  return data
+    .toString()
+    .split('\n')
+    .filter(isNotCommentLine)
+    .map(line => parseLineAsKeyValue(line))
+    .filter(([key]) => !!key) as KeyValueTuple[];
+};
+
+export default main;

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -11,7 +11,6 @@ interface IRunnerParams {
     herokuToken?: string;
     herokuAppName?: string;
     providerPaths: Array<string>;
-    allowMissing?: boolean;
   };
   version: string;
 }
@@ -62,7 +61,6 @@ const main = async ({ params, version }: IRunnerParams) => {
     herokuToken,
     herokuAppName,
     providerPaths,
-    allowMissing,
   } = params;
 
   const providersToBeUsed = !providerPaths
@@ -93,7 +91,6 @@ const main = async ({ params, version }: IRunnerParams) => {
     fileLocation: envVars,
     config: { region, herokuToken, herokuAppName },
     providers,
-    allowMissing,
   }).then(keyValueTuples => {
     keyValueTuples.map(print);
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -5,7 +5,7 @@ interface IRunnerParams {
   params: {
     isHeroku?: boolean;
     isAws?: boolean;
-    envVars?: Array<string>;
+    envVars?: string;
     region?: string;
     addExport: boolean;
     herokuToken?: string;
@@ -91,8 +91,8 @@ const main = async ({ params, version }: IRunnerParams) => {
     fileLocation: envVars,
     config: { region, herokuToken, herokuAppName },
     providers,
-  }).then(data => {
-    Object.entries(data).map(print);
+  }).then(keyValueTuples => {
+    keyValueTuples.map(print);
 
     console.log(`# Done! Generated on ${new Date(Date.now())}`);
   });

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -11,6 +11,7 @@ interface IRunnerParams {
     herokuToken?: string;
     herokuAppName?: string;
     providerPaths: Array<string>;
+    allowMissing?: boolean;
   };
   version: string;
 }
@@ -61,6 +62,7 @@ const main = async ({ params, version }: IRunnerParams) => {
     herokuToken,
     herokuAppName,
     providerPaths,
+    allowMissing,
   } = params;
 
   const providersToBeUsed = !providerPaths
@@ -91,6 +93,7 @@ const main = async ({ params, version }: IRunnerParams) => {
     fileLocation: envVars,
     config: { region, herokuToken, herokuAppName },
     providers,
+    allowMissing,
   }).then(keyValueTuples => {
     keyValueTuples.map(print);
 


### PR DESCRIPTION
Keep the order of the variables used in the template

For instance, if you have the following template:
```sh
export PORT=8007
export HOST=localhost:$PORT
```

The current version of `genvv` would reorder to:

```sh
export HOST=localhost:$PORT
export PORT=8007
```

